### PR TITLE
Modernization Phase 6 (1/2) — UI deploys from the monorepo

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,32 @@
+name: Frontend Deploy
+
+# Deploys the UI from the monorepo to the kinobotz-ui Heroku app.
+# Requires a HEROKU_API_KEY repo secret. Once verified, disconnect the
+# kinobotz-ui app's GitHub auto-deploy from the standalone repo and archive it.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-deploy.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    env:
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Heroku container login
+        run: heroku container:login
+
+      - name: Build & push UI image (frontend/Dockerfile)
+        run: heroku container:push web -a kinobotz-ui
+
+      - name: Release
+        run: heroku container:release web -a kinobotz-ui


### PR DESCRIPTION
First step of Phase 6: make the monorepo deploy the UI (today only the backend deploys on merge; the live UI still deploys from the standalone kinobotz-ui repo).

- Adds `.github/workflows/frontend-deploy.yml`: on push to `main` touching `frontend/**`, builds `frontend/Dockerfile` and `heroku container:push`/`release` to the **kinobotz-ui** app.

## Before this works
1. Add a **`HEROKU_API_KEY`** repo secret (your Heroku auth token).
2. After the first monorepo-sourced deploy is verified live, **disconnect the kinobotz-ui app's GitHub auto-deploy** from the standalone `kinobotz-ui` repo (Heroku dashboard) and archive that repo — otherwise both could deploy.

## Next (Phase 6, part 2 — separate PR)
The Vite + Pinia + ESLint 9 + TypeScript + SignalR-cleanup migration. That one changes build tooling and has runtime behaviors (overlay SignalR, OAuth, deep-route styling) that should be **smoke-tested in a browser** before merge — best done when you can poke the running UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)