### PR TITLE
ci: install Heroku CLI in frontend-deploy workflow

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # GitHub runners no longer ship the Heroku CLI.
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+
       - name: Heroku container login
         run: heroku container:login
 


### PR DESCRIPTION
Fixes the Frontend Deploy workflow, which failed with exit 127 (`heroku: command not found`) — GitHub runners no longer ship the Heroku CLI.

Adds an install step before the container login/push/release. **Validated end-to-end** by running the workflow from this branch: all steps green (install → login → push → release, 1m11s), UI deployed to the kinobotz-ui app from the monorepo's `frontend/`.

Merge so future pushes to `frontend/**` on `main` auto-deploy the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)