### PR TITLE
Modernization Phase 8 — feature reference + architecture docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,64 @@
+# Architecture
+
+Kinobotz is a Twitch bot platform: a chat bot worker, a REST/realtime API, and a Vue dashboard,
+all in this monorepo (`backend/` + `frontend/`), on **.NET 10** and Redis.
+
+## Components
+
+| Component | Project / path | Role |
+|-----------|----------------|------|
+| **Bot worker** | `backend/twitchBot` (`kinobotz` dyno) | Connects to Twitch IRC + events, dispatches chat commands, runs the token-refresh job |
+| **Web API** | `backend/webapi` (`web` dyno) | REST API for the dashboard (JWT auth) + SignalR `/overlayHub` for overlay audio |
+| **Infrastructure** | `backend/Infrastructure` | Redis repositories, the GPT chat service (`Microsoft.Extensions.AI`), JWT, overlay hub |
+| **Entities** | `backend/Entities` | Shared domain models (`BotConnection`, `Command`, `AuditLog`, …) |
+| **Dashboard** | `frontend/` | Vue 3 SPA (Twitch OAuth → JWT) for config, stats, GPT behaviors, and the TTS overlay |
+
+## Command flow (chat → response)
+
+```mermaid
+flowchart LR
+  Chat["Twitch chat (IRC)"] --> Bot["Bot.OnMessageReceived"]
+  Bot --> Factory["CommandFactory.Build\n(% prefix or @kinobotz)"]
+  Factory --> Dispatch["CommandDispatcher.Send\n(resolves ICommandHandler&lt;T&gt;)"]
+  Dispatch --> Handler["BaseCommandHandler\n(access · cooldown · audit)"]
+  Handler --> Svc["External service\n(OpenAI / ElevenLabs / Twitch / Redis)"]
+  Handler --> Resp["Response"]
+  Resp --> Send["TwitchClient.SendReply/Message"]
+  Handler --> Audit["AuditLog → Redis"]
+```
+
+Commands are plain `ICommandHandler<TCommand>` resolved from DI by the `CommandDispatcher`
+(MediatR was removed). `BaseCommandHandler` wraps each with the existence/enabled check,
+access-level gate, cooldown, and audit logging.
+
+## Realtime + dashboard
+
+- **Overlay audio:** `%tts` → `IGptChatService`/ElevenLabs produces audio → the bot relays it to
+  the API, which broadcasts it over SignalR `/overlayHub` to the browser overlay (`OverlayApp`).
+- **Dashboard:** Vue app → Twitch OAuth → `POST /twitch/login` → JWT → REST calls
+  (`/botconnection`, `/commands`, `/public/gptBehaviors`, …).
+
+## Integrations
+
+- **Twitch** — IRC (chat, via TwitchLib), Helix (clips, channel title, follows), PubSub
+  (bits, subs, stream up/down, channel points). *PubSub → EventSub migration is a future phase.*
+- **OpenAI** — `Microsoft.Extensions.AI` `IChatClient` behind `IGptChatService` (quota circuit-breaker).
+- **ElevenLabs** — text-to-speech.
+- **Discord** — webhooks for clips / TTS audio.
+- **Redis** — the only datastore (cache + system-of-record). See [redis-key-schema.md](redis-key-schema.md).
+
+## Data & deployment
+
+- **Data:** Redis only (free Redis Cloud add-on); System.Text.Json serialization.
+- **Deployment:** backend auto-deploys from `main` (Heroku GitHub integration, container stack);
+  UI deploys via GitHub Actions. Full detail in [deployment-and-ops.md](deployment-and-ops.md).
+
+## Local development
+
+- **Backend:** `dotnet build backend/twitchBot.sln`; `dotnet test backend/twitchBot.sln`.
+  Config via environment / `.env` (see `.env_example`): Twitch client id/secret, bot tokens,
+  `redis_host`/`redis_password`, `jwt`, `OPENAI_API_KEY`, `ELEVEN_LABS_API_KEY`.
+- **Frontend:** in `frontend/`, `npm ci` then `npm run serve` (dev) / `npm run build`.
+  Runtime config (`API_URL`, Twitch client id, redirect URI) is injected via `config.js`.
+
+See also: [commands.md](commands.md) · [deployment-and-ops.md](deployment-and-ops.md) · [redis-key-schema.md](redis-key-schema.md).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,54 @@
+# Command & Feature Reference
+
+Kinobotz is a Twitch chat bot. Chat commands start with `%`; mentioning **`@kinobotz`** triggers a GPT reply. This reference is derived from `Entities/Commands.cs` (the default command set) and the handlers in `twitchBot/Handlers/`.
+
+## Access levels & cooldowns
+
+A command runs when the caller's access level is **≥** the command's required level. Ordering (low→high): `Default < Vip < Subscriber < Moderator < Broadcaster < Premium < Admin`. The user `k1notv` is hard-coded as **Admin** (and bypasses cooldowns). Cooldowns are per-user unless marked **global** (shared across the channel). Per-channel command config (enabled/disabled, access, cooldown) is editable from the dashboard and stored in Redis.
+
+## Commands
+
+| Command | Access | Cooldown | What it does | Integrations |
+|---------|--------|----------|--------------|--------------|
+| `%gpt <text>` *(or `@kinobotz <text>`)* | Default | — | GPT reply, shaped by the channel's behavior prompt, capped at 500 chars | OpenAI via `Microsoft.Extensions.AI` |
+| `%tts <voiceName>: <text>` *(or `%tts` to list voices)* | Default | 10 min (global) | Text-to-speech via ElevenLabs → played on the overlay; optionally posted to a Discord webhook. 1000 chars/user/day | ElevenLabs, SignalR overlay, Discord |
+| `%clip` | Default | — | Creates a Twitch clip of the stream; posts the link to Discord if configured | Twitch Helix, Discord |
+| `%lm <username>` | Default | — | Shows the last chat message stored for a user | Redis |
+| `%ff <username>` | Default | — | Looks up the first channel a user followed (cached) | Twitch Helix, Redis |
+| `%commands` | Default | — | Lists the available commands | — |
+| `%gptbehavior <instructions>` | Default | 10 min (global) | Sets the GPT system prompt ("personality") for the channel; records who set it | Redis |
+| `%gptbehaviordef` | Default | — | Shows the current GPT behavior and who defined it | Redis |
+| `%notify` | Default | — | Joins the stream up/down notification list | Redis |
+| `%command <add\|update\|delete> <name> <content>` | Moderator | — | Manages custom text commands (stored in Redis) | Redis |
+| `%title <new title>` | Moderator | — | Updates the stream title (max 140 chars) | Twitch Helix |
+| `%enable <command>` | Moderator | — | Re-enables a disabled command | Redis |
+| `%disable <command>` | Moderator | — | Disables a command (can't disable `enable`/`disable`) | Redis |
+| `%rtitle` | Broadcaster | — | Generates a 1–5 word random stream title via GPT and applies it | OpenAI, Twitch Helix |
+
+> `%gptbehavior` with no argument behaves like `%gptbehaviordef` (returns the current behavior).
+
+## Event-driven features
+
+These fire automatically (no command), gated by per-channel settings on the dashboard:
+
+- **`@kinobotz` mention** → routes to the GPT command.
+- **Bits / Cheers** — if `UseTtsOnBits` and the amount ≥ `TtsMinimumBitAmount`, the cheer message is auto-read via TTS (Cheer prefixes stripped).
+- **Subscriptions** — if `UseTtsOnSubscription` and months ≥ `TtsMinimumResubMonthsAmount`, the sub message is auto-read via TTS.
+- **Stream up / down** — posts a message tagging everyone on the `%notify` list.
+- **Pyramid detection** — the bot reacts to chat "pyramids".
+
+## Audit log
+
+Every command execution is logged to Redis (a global `auditlog` set and a per-channel
+`{botConnectionId}:auditlog` set): command, user, access level, original chat message,
+timestamp, channel, and the response. Admins can view it via `GET /commands/log` and the
+dashboard **Stats** page.
+
+## TTS notes
+
+- Voices are resolved from ElevenLabs and cached per channel.
+- A channel can set a default voice; bits/sub auto-TTS uses it (or a random voice if unset).
+- ElevenLabs key: `Premium` channels use the global `ELEVEN_LABS_API_KEY`; others configure
+  their own key on the dashboard. Per-user daily character limit: 1000.
+
+See also: [architecture.md](architecture.md) · [deployment-and-ops.md](deployment-and-ops.md) · [redis-key-schema.md](redis-key-schema.md).


### PR DESCRIPTION
Phase 8: documentation (your "document all existing functionality" goal). Docs-only — no code/CI change.

- **`docs/commands.md`** — complete command/feature reference: every command with syntax, access level, cooldown, behavior, and integration; the event-driven features (`@kinobotz` mention, bits/sub auto-TTS, stream notify, pyramid); and the audit log.
- **`docs/architecture.md`** — components, command flow (Mermaid diagram), realtime/overlay path, integrations, data + deployment, and local dev setup.

Together with `redis-key-schema.md` (Phase 5) and `deployment-and-ops.md` (Phase 7), the `docs/` set now covers features, data, deployment, and architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)