### PR TITLE
Modernization Phase 4 (1/2) — EventSub webhook receive path (observe mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -433,3 +433,6 @@ $RECYCLE.BIN/
 !.vscode/extensions.json
 
 .env
+# Local test artifacts
+.playwright-mcp/
+k1no-tv-vite-live.png

--- a/backend/Infrastructure/Services/EventSubBus.cs
+++ b/backend/Infrastructure/Services/EventSubBus.cs
@@ -1,0 +1,41 @@
+using StackExchange.Redis;
+using StackExchange.Redis.Extensions.Core.Abstractions;
+
+namespace Infrastructure.Services
+{
+    /// <summary>
+    /// Bridges EventSub notifications from the web tier (where the public callback lives)
+    /// to the worker tier (where the bot acts), over a Redis pub/sub channel — both tiers
+    /// already share Redis.
+    /// </summary>
+    public interface IEventSubBus
+    {
+        Task PublishAsync(string payload);
+        Task SubscribeAsync(Func<string, Task> handler);
+    }
+
+    public class EventSubBus : IEventSubBus
+    {
+        private static readonly RedisChannel Channel = new("eventsub:notifications", RedisChannel.PatternMode.Literal);
+        private readonly ISubscriber _subscriber;
+
+        public EventSubBus(IRedisClient redisClient)
+        {
+            _subscriber = redisClient.Db0.Database.Multiplexer.GetSubscriber();
+        }
+
+        public Task PublishAsync(string payload) => _subscriber.PublishAsync(Channel, payload);
+
+        public async Task SubscribeAsync(Func<string, Task> handler)
+        {
+            var queue = await _subscriber.SubscribeAsync(Channel);
+            queue.OnMessage(async message =>
+            {
+                if (message.Message.HasValue)
+                {
+                    await handler(message.Message.ToString());
+                }
+            });
+        }
+    }
+}

--- a/backend/Infrastructure/Services/EventSubSignature.cs
+++ b/backend/Infrastructure/Services/EventSubSignature.cs
@@ -1,0 +1,28 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Infrastructure.Services
+{
+    /// <summary>Verifies the HMAC-SHA256 signature Twitch sends on every EventSub webhook
+    /// request (Twitch-Eventsub-Message-Signature), computed over id + timestamp + raw body.</summary>
+    public static class EventSubSignature
+    {
+        public static bool IsValid(string? secret, string? messageId, string? timestamp, string body, string? signatureHeader)
+        {
+            if (string.IsNullOrEmpty(secret) || string.IsNullOrEmpty(messageId)
+                || string.IsNullOrEmpty(timestamp) || string.IsNullOrEmpty(signatureHeader))
+            {
+                return false;
+            }
+
+            var message = messageId + timestamp + body;
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+            var expected = "sha256=" + Convert.ToHexString(hash).ToLowerInvariant();
+
+            return CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(expected),
+                Encoding.UTF8.GetBytes(signatureHeader));
+        }
+    }
+}

--- a/backend/kinobotz.Tests/EventSubSignatureTests.cs
+++ b/backend/kinobotz.Tests/EventSubSignatureTests.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using System.Text;
+using Infrastructure.Services;
+
+namespace kinobotz.Tests;
+
+// Verifies the EventSub webhook HMAC signature check (id + timestamp + body).
+public class EventSubSignatureTests
+{
+    private const string Secret = "s3cr3t-value";
+    private const string Id = "msg-1";
+    private const string Ts = "2026-06-18T00:00:00Z";
+    private const string Body = "{\"subscription\":{\"type\":\"channel.cheer\"}}";
+
+    private static string Sign(string secret, string id, string ts, string body)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(id + ts + body));
+        return "sha256=" + Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    [Fact]
+    public void Valid_signature_passes()
+    {
+        var sig = Sign(Secret, Id, Ts, Body);
+        Assert.True(EventSubSignature.IsValid(Secret, Id, Ts, Body, sig));
+    }
+
+    [Fact]
+    public void Tampered_body_fails()
+    {
+        var sig = Sign(Secret, Id, Ts, Body);
+        Assert.False(EventSubSignature.IsValid(Secret, Id, Ts, "{\"tampered\":true}", sig));
+    }
+
+    [Fact]
+    public void Wrong_secret_fails()
+    {
+        var sig = Sign(Secret, Id, Ts, Body);
+        Assert.False(EventSubSignature.IsValid("different-secret", Id, Ts, Body, sig));
+    }
+
+    [Fact]
+    public void Missing_signature_fails()
+    {
+        Assert.False(EventSubSignature.IsValid(Secret, Id, Ts, Body, null));
+    }
+}

--- a/backend/twitchBot/Jobs/EventSubObserver.cs
+++ b/backend/twitchBot/Jobs/EventSubObserver.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Infrastructure.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace twitchBot.Jobs
+{
+    // Phase 4 step 1 (observe mode): logs EventSub notifications relayed from the web tier,
+    // so we can confirm end-to-end webhook delivery while PubSub still handles the real
+    // events. Step 2 routes these into the command pipeline and retires PubSub.
+    public class EventSubObserver : IHostedService
+    {
+        private readonly IEventSubBus _bus;
+        private readonly ILogger<EventSubObserver> _logger;
+
+        public EventSubObserver(IEventSubBus bus, ILogger<EventSubObserver> logger)
+        {
+            _bus = bus;
+            _logger = logger;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            await _bus.SubscribeAsync(payload =>
+            {
+                _logger.LogInformation("EventSub notification received (observe mode): {Payload}", payload);
+                return Task.CompletedTask;
+            });
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/backend/twitchBot/Program.cs
+++ b/backend/twitchBot/Program.cs
@@ -55,6 +55,8 @@ namespace twitchBot
                         services.AddTransient<IBot, Bot>();
                         
                         services.AddGptChatService(_configuration);
+                        services.AddSingleton<IEventSubBus, EventSubBus>();
+                        services.AddHostedService<EventSubObserver>();
                         services.AddHttpClient();
                         services.AddHttpClient<KinobotzService>();
                         services.AddTransient<ICommandFactory, CommandFactory>();

--- a/backend/webapi/Controllers/EventSubController.cs
+++ b/backend/webapi/Controllers/EventSubController.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using System.Text.Json;
+using Infrastructure.Services;
+using Microsoft.AspNetCore.Mvc;
+using StackExchange.Redis.Extensions.Core.Abstractions;
+
+namespace webapi.Controllers
+{
+    // Public Twitch EventSub webhook callback. Verifies the signature, answers the
+    // one-time verification challenge, dedupes redeliveries, and relays notifications
+    // to the worker over the Redis bus (where the bot acts).
+    [ApiController]
+    public class EventSubController : ControllerBase
+    {
+        private readonly IConfiguration _configuration;
+        private readonly IEventSubBus _bus;
+        private readonly IRedisClient _redisClient;
+        private readonly ILogger<EventSubController> _logger;
+
+        public EventSubController(IConfiguration configuration, IEventSubBus bus, IRedisClient redisClient, ILogger<EventSubController> logger)
+        {
+            _configuration = configuration;
+            _bus = bus;
+            _redisClient = redisClient;
+            _logger = logger;
+        }
+
+        [HttpPost("~/eventsub/callback")]
+        public async Task<IActionResult> Callback()
+        {
+            using var reader = new StreamReader(Request.Body, Encoding.UTF8);
+            var body = await reader.ReadToEndAsync();
+
+            var messageId = Request.Headers["Twitch-Eventsub-Message-Id"].ToString();
+            var timestamp = Request.Headers["Twitch-Eventsub-Message-Timestamp"].ToString();
+            var signature = Request.Headers["Twitch-Eventsub-Message-Signature"].ToString();
+            var messageType = Request.Headers["Twitch-Eventsub-Message-Type"].ToString();
+
+            if (!EventSubSignature.IsValid(_configuration["eventsub_secret"], messageId, timestamp, body, signature))
+            {
+                _logger.LogWarning("EventSub callback: invalid signature (message {MessageId})", messageId);
+                return Unauthorized();
+            }
+
+            switch (messageType)
+            {
+                case "webhook_callback_verification":
+                    var challenge = JsonDocument.Parse(body).RootElement.GetProperty("challenge").GetString();
+                    return Content(challenge ?? string.Empty, "text/plain");
+
+                case "revocation":
+                    _logger.LogWarning("EventSub subscription revoked: {Body}", body);
+                    return Ok();
+
+                case "notification":
+                    var seenKey = $"eventsub:msg:{messageId}";
+                    if (await _redisClient.Db0.ExistsAsync(seenKey))
+                    {
+                        return Ok();
+                    }
+                    await _redisClient.Db0.AddAsync(seenKey, true, TimeSpan.FromMinutes(10));
+                    await _bus.PublishAsync(body);
+                    return Ok();
+
+                default:
+                    return Ok();
+            }
+        }
+    }
+}

--- a/backend/webapi/Program.cs
+++ b/backend/webapi/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddCors(options => options.AddPolicy("CorsPolicy",
             .AllowCredentials();
     }));
 builder.Services.AddSingleton<IOverlayHub, OverlayHub>();
+builder.Services.AddSingleton<IEventSubBus, EventSubBus>();
 builder.Services.AddScoped<IJwtService, JwtService>();
 builder.Services.AddHttpClient();
 builder.Services.AddScoped<IBotConnectionRepository, BotConnectionRepository>();


### PR DESCRIPTION
First, safe step of the PubSub→EventSub migration (webhook transport). **PubSub is untouched and still handles all events — zero behavior change in prod.** This just stands up the webhook *delivery* path so we can validate it live before cutting over.

## What's here
- **webapi `POST /eventsub/callback`** — verifies the Twitch HMAC signature, answers the verification challenge, dedupes redeliveries (Redis), and relays notifications onto a **Redis pub/sub bus**.
- **`EventSubBus`** — web→worker bridge over Redis (the callback lives in the web tier; the bot acts in the worker tier).
- **`EventSubObserver`** (worker) — logs relayed notifications in **observe mode**.
- **`EventSubSignature`** + 4 unit tests. 24 tests green.

## To activate & validate (live — needs you)
1. Set a `eventsub_secret` config var on the **kinobotz** app (any strong random string).
2. Create a test subscription pointing at `https://kinobotz.herokuapp.com/eventsub/callback` with that secret — e.g. via the Twitch CLI:
   `twitch event subscribe stream.online -F https://kinobotz.herokuapp.com/eventsub/callback -s <eventsub_secret> -t <broadcaster_id>`
   → the callback should answer the challenge and the sub becomes **enabled**.
3. Trigger/await a real event → the **worker logs** `EventSub notification received (observe mode)`.

## Step 2 (next PR)
Programmatic subscription management (Helix **app token**, idempotent, per channel — also decouples from the flaky per-channel user tokens), route events into the command pipeline (needs a small refactor to map a broadcaster → its bot instance), then **remove PubSub**.

## Caveat
The **Eco web dyno sleeps** — a cold start can exceed Twitch's callback timeout and drop a delivery (Twitch retries). For reliable webhooks, the web dyno should not sleep (Basic ~$7/mo). Fine to evaluate during validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)