### PR TITLE
Fix bot chat connection on Eco (async Connect) + connection diagnostics + integration tests

### DIFF
--- a/backend/kinobotz.Tests/TwitchConnectionIntegrationTests.cs
+++ b/backend/kinobotz.Tests/TwitchConnectionIntegrationTests.cs
@@ -1,0 +1,91 @@
+using TwitchLib.Client;
+using TwitchLib.Client.Models;
+using TwitchLib.Communication.Clients;
+using TwitchLib.Communication.Models;
+
+namespace kinobotz.Tests;
+
+// Live integration tests: connect to Twitch IRC with the bot credentials and verify the
+// bot can join and (visibly) send. Gated on KINOBOTZ_BOT_TOKEN so CI without secrets stays
+// green. Uses the bot's OWN channel (#kinobotz) so sending a test message is safe.
+// Run locally:
+//   KINOBOTZ_BOT_TOKEN=<token> KINOBOTZ_BOT_USERNAME=kinobotz dotnet test --filter TwitchConnection
+public class TwitchConnectionIntegrationTests
+{
+    private const string Channel = "kinobotz"; // the bot's own channel
+
+    [Fact]
+    public async Task Bot_can_connect_join_and_send_message()
+    {
+        var token = Environment.GetEnvironmentVariable("KINOBOTZ_BOT_TOKEN");
+        if (string.IsNullOrEmpty(token)) return; // gated: no creds (e.g. CI) -> nothing to assert
+        var username = Environment.GetEnvironmentVariable("KINOBOTZ_BOT_USERNAME") ?? "kinobotz";
+
+        var client = new TwitchClient(new WebSocketClient(new ClientOptions()));
+        var joined = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sent = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failure = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var message = $"kinobotz integration test - connection OK ({DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC)";
+
+        client.OnJoinedChannel += (_, e) =>
+        {
+            joined.TrySetResult(e.Channel);
+            client.SendMessage(Channel, message); // visible proof in #kinobotz chat
+        };
+        client.OnMessageSent += (_, e) => sent.TrySetResult(e.SentMessage.Message);
+        client.OnConnectionError += (_, e) => failure.TrySetResult($"connection error: {e.Error?.Message}");
+        client.OnIncorrectLogin += (_, e) => failure.TrySetResult($"incorrect login: {e.Exception?.Message}");
+
+        client.Initialize(new ConnectionCredentials(username, token), Channel);
+        client.Connect();
+
+        await Task.WhenAny(sent.Task, failure.Task, Task.Delay(TimeSpan.FromSeconds(25)));
+        await Task.Delay(2000); // give the message time to appear in chat
+        try { client.Disconnect(); } catch { /* ignore */ }
+
+        if (failure.Task.IsCompletedSuccessfully)
+        {
+            Assert.Fail($"Bot could not connect as '{username}': {failure.Task.Result}");
+        }
+
+        Assert.True(joined.Task.IsCompletedSuccessfully, $"Did not receive a JOIN confirmation for #{Channel}.");
+        Assert.True(sent.Task.IsCompletedSuccessfully, $"Joined #{Channel} but failed to send a message (send path broken).");
+    }
+
+    // Replicates the worker's pattern: one TwitchClient PER channel (N concurrent connections
+    // as the same account) to diagnose whether concurrent-connection limits drop joins.
+    [Fact]
+    public async Task Bot_multiple_concurrent_connections_all_join()
+    {
+        var token = Environment.GetEnvironmentVariable("KINOBOTZ_BOT_TOKEN");
+        if (string.IsNullOrEmpty(token)) return;
+        var username = Environment.GetEnvironmentVariable("KINOBOTZ_BOT_USERNAME") ?? "kinobotz";
+
+        var channels = new[]
+        {
+            "marciosaales", "vilelandre", "splintergprz", "xandghost", "elrikizin",
+            "themalkavianx", "shemyazah", "slimclic", "zeszin", "k1notv"
+        };
+
+        var joined = new System.Collections.Concurrent.ConcurrentDictionary<string, bool>();
+        var clients = new List<TwitchClient>();
+
+        foreach (var ch in channels)
+        {
+            var client = new TwitchClient(new WebSocketClient(new ClientOptions()));
+            client.OnJoinedChannel += (_, e) => joined[e.Channel.ToLowerInvariant()] = true;
+            client.Initialize(new ConnectionCredentials(username, token), ch);
+            client.Connect();
+            clients.Add(client);
+        }
+
+        await Task.Delay(TimeSpan.FromSeconds(30));
+        foreach (var c in clients) { try { c.Disconnect(); } catch { /* ignore */ } }
+
+        var joinedList = string.Join(", ", joined.Keys.OrderBy(x => x));
+        var missing = channels.Where(c => !joined.ContainsKey(c.ToLowerInvariant())).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"Joined {joined.Count}/{channels.Length}. JOINED: [{joinedList}]. MISSING: [{string.Join(", ", missing)}]");
+    }
+}

--- a/backend/twitchBot/Bot.cs
+++ b/backend/twitchBot/Bot.cs
@@ -55,9 +55,34 @@ namespace twitchBot
             _twitchClient.OnConnected += TwitchClientOnConnected;
             _twitchClient.OnUserBanned += TwitchClientOnUserBanned;
             _twitchClient.OnMessageReceived += TwitchClientOnMessageReceived;
+            _twitchClient.OnJoinedChannel += TwitchClientOnJoinedChannel;
+            _twitchClient.OnConnectionError += TwitchClientOnConnectionError;
+            _twitchClient.OnIncorrectLogin += TwitchClientOnIncorrectLogin;
+            _twitchClient.OnDisconnected += TwitchClientOnDisconnected;
         }
 
         public string ChannelId => _botConnection?.ChannelId;
+
+        // ── connection diagnostics ──
+        private void TwitchClientOnJoinedChannel(object sender, OnJoinedChannelArgs e)
+        {
+            _logger.LogInformation($"[conn] JOINED channel '{e.Channel}' as '{e.BotUsername}'");
+        }
+
+        private void TwitchClientOnConnectionError(object sender, OnConnectionErrorArgs e)
+        {
+            _logger.LogError($"[conn] CONNECTION ERROR as '{e.BotUsername}': {e.Error?.Message}");
+        }
+
+        private void TwitchClientOnIncorrectLogin(object sender, OnIncorrectLoginArgs e)
+        {
+            _logger.LogError(e.Exception, $"[conn] INCORRECT LOGIN for '{e.Exception?.Username}'");
+        }
+
+        private void TwitchClientOnDisconnected(object sender, TwitchLib.Communication.Events.OnDisconnectedEventArgs e)
+        {
+            _logger.LogWarning("[conn] DISCONNECTED from Twitch IRC");
+        }
 
         // ── EventSub-driven handlers (replace the former Twitch PubSub events) ──
         // Invoked by EventSubRouter when a notification for this channel arrives.
@@ -137,7 +162,7 @@ namespace twitchBot
             _twitchClient.SendMessage(_botConnection.Login, $"{_botConnection.Login} stream ended. Notifying users: {users}");
         }
 
-        public Task Connect(BotConnection botConnection)
+        public async Task Connect(BotConnection botConnection)
         {
             _botConnection = botConnection;
 
@@ -155,20 +180,20 @@ namespace twitchBot
             {
                 try
                 {
-                    //refreshing token in case it has expired
-                    var response = _twitchApi.Auth.RefreshAuthTokenAsync(_botConnection.RefreshToken, _configuration["twitch_client_secret"], _configuration["twitch_client_id"]).Result;
+                    //refreshing token in case it has expired (awaited - blocking .Result starved the Eco dyno thread pool)
+                    var response = await _twitchApi.Auth.RefreshAuthTokenAsync(_botConnection.RefreshToken, _configuration["twitch_client_secret"], _configuration["twitch_client_id"]);
                     _twitchApi.Settings.AccessToken = response.AccessToken;
                     _botConnection.AccessToken = response.AccessToken;
                     _botConnection.RefreshToken = response.RefreshToken;
 
                     if (string.IsNullOrEmpty(_botConnection.ChannelId) || _botConnection.ChannelId == "string")
                     {
-                        var user = _twitchApi.Helix.Users.GetUsersAsync(logins: new List<string>() { _botConnection.Login }).Result;
+                        var user = await _twitchApi.Helix.Users.GetUsersAsync(logins: new List<string>() { _botConnection.Login });
 
                         _botConnection.ChannelId = user.Users[0].Id;
                     }
 
-                    _botConnectionRepository.SaveOrUpdate(_botConnection);
+                    await _botConnectionRepository.SaveOrUpdate(_botConnection);
 
                     var aTimer = new Timer(TimeSpan.FromSeconds(response.ExpiresIn).TotalMilliseconds);
                     aTimer.Elapsed += OnOAuthTokenRefreshTimer;
@@ -183,13 +208,19 @@ namespace twitchBot
 
             _commandFactory.Setup(_twitchApi, _botConnection);
 
-            var credentials = new ConnectionCredentials(_configuration["twitch_username"], _configuration["bot_access_token"]);
+            var username = _configuration["twitch_username"];
+            var botToken = _configuration["bot_access_token"];
+            _logger.LogInformation($"[conn] Connecting: channel='{_botConnection.Login}' channelId='{_botConnection.ChannelId}' configuredUsername='{username}' botTokenSet={!string.IsNullOrEmpty(botToken)} botTokenLen={botToken?.Length ?? 0}");
+
+            if (string.IsNullOrEmpty(username))
+                _logger.LogWarning("[conn] twitch_username is EMPTY - ConnectionCredentials will have no username, which can break joins.");
+
+            var credentials = new ConnectionCredentials(username, botToken);
 
             _twitchClient.Initialize(credentials);
             _twitchClient.Connect();
             _twitchClient.JoinChannel(_botConnection.Login);
-
-            return Task.CompletedTask;
+            _logger.LogInformation($"[conn] Issued Connect() + JoinChannel('{_botConnection.Login}')");
         }
 
         private void OnOAuthTokenRefreshTimer(object sender, ElapsedEventArgs e)

--- a/backend/twitchBot/Orchestrator.cs
+++ b/backend/twitchBot/Orchestrator.cs
@@ -60,7 +60,8 @@ namespace twitchBot
                     if (Connections.ContainsKey(botConnection.Id)) continue;
 
                     var bot = (IBot)_serviceProvider.GetService(typeof(IBot));
-                    bot?.Connect(botConnection);
+                    if (bot != null)
+                        await bot.Connect(botConnection);
 
                     Connections.Add(botConnection.Id, botConnection);
 


### PR DESCRIPTION
The bot connects to Twitch IRC but doesn't join/receive in the deployed worker. This diagnoses and fixes it.

## Diagnosis (via the new integration tests)
Run locally against the real bot account, these **pass**:
- connect → join **#kinobotz** → **send a message** (visually confirmed in chat ✅)
- open **10 concurrent connections** (one per channel) → all 10 join

So credentials, account, join, and send all work from a clean machine. The **deployed 1-CPU Eco dyno** is the only thing that fails — pointing at **thread-pool starvation**: `Connect()` made blocking `.Result` calls (token refresh + user lookup) for each of ~10 channels during startup, starving the pool right when the WebSocket JOIN handshakes need threads (a multi-core machine doesn't starve, so local works).

## Fix
- **`Bot.Connect` is now async** — `await`s `RefreshAuthTokenAsync` / `GetUsersAsync` / `SaveOrUpdate` instead of `.Result`. `Orchestrator` awaits it. No more thread blocking during startup.
- **Connection diagnostics**: logs `[conn] JOINED` / connection error / incorrect login / disconnected, plus the connection params (also surfaces that `twitch_username` is empty).

## Integration tests (you asked for these)
`TwitchConnectionIntegrationTests` — gated on `KINOBOTZ_BOT_TOKEN` (skip in CI without the secret). Run locally:
```
KINOBOTZ_BOT_TOKEN=<token> KINOBOTZ_BOT_USERNAME=kinobotz dotnet test --filter TwitchConnection
```

## After merge
Deploy restarts the worker; watch for **`[conn] JOINED channel 'k1notv'`** in the logs and test `%commands`. If joins still fail, the fallback is consolidating to one IRC connection for all channels (10× less startup load) — but the async fix should resolve the starvation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)