### PR TITLE
Fix: bot never joins chat after .NET 10 upgrade (TwitchLib join race)

### DIFF
--- a/backend/twitchBot/Bot.cs
+++ b/backend/twitchBot/Bot.cs
@@ -217,10 +217,13 @@ namespace twitchBot
 
             var credentials = new ConnectionCredentials(username, botToken);
 
-            _twitchClient.Initialize(credentials);
+            // Pass the channel to Initialize so TwitchLib auto-joins once the connection is
+            // ready. The old "Initialize() + Connect() + JoinChannel()" pattern raced on .NET 10
+            // (the manual join fired before the connection/auth completed and was silently lost),
+            // which is why the bot connected but never actually joined any channel.
+            _twitchClient.Initialize(credentials, _botConnection.Login);
             _twitchClient.Connect();
-            _twitchClient.JoinChannel(_botConnection.Login);
-            _logger.LogInformation($"[conn] Issued Connect() + JoinChannel('{_botConnection.Login}')");
+            _logger.LogInformation($"[conn] Initialized with channel + Connect() for '{_botConnection.Login}'");
         }
 
         private void OnOAuthTokenRefreshTimer(object sender, ElapsedEventArgs e)


### PR DESCRIPTION
## Root cause (found + reproduced)
The bot connected to Twitch but **never actually joined any channel** — it wasn't in chatter lists and ignored all commands. The worker's connect sequence was:
```
_twitchClient.Initialize(credentials);   // no channel
_twitchClient.Connect();
_twitchClient.JoinChannel(login);          // fires before the connection/auth is ready
```
On **.NET 7** this worked. The **.NET 10 upgrade** changed the timing so TwitchLib 3.5.3 **silently drops the join** issued before the connection completes — the socket connects (CAP ACK + PING/PONG), but Twitch never gets/confirms the JOIN (no `353`, no `OnJoinedChannel`).

This is why it looked "Heroku-only" and "intermittent" — it was actually the runtime upgrade, reproducible anywhere on .NET 10.

## Reproduced locally
New integration test ran the worker's exact pattern → **fails to join**. The auto-join pattern (`Initialize(credentials, channel)`) → **joins and sends** (verified by posting a message in #kinobotz).

## Fix
```
_twitchClient.Initialize(credentials, login); // auto-join once connected
_twitchClient.Connect();
```
Plus `[conn]` connection diagnostics and gated live integration tests (`KINOBOTZ_BOT_TOKEN`).

## After merge
Deploy restarts the worker; you should see `[conn] JOINED channel 'k1notv'`, kinobotz appears in chat, and `%commands` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)