### PR TITLE
Switch %gpt to Groq (free tier) — configurable OpenAI-compatible provider

### DIFF
--- a/backend/Infrastructure/Services/GptServiceCollectionExtensions.cs
+++ b/backend/Infrastructure/Services/GptServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,21 +9,39 @@ namespace Infrastructure.Services
 {
     public static class GptServiceCollectionExtensions
     {
+        // Defaults to Groq (free tier) via its OpenAI-compatible endpoint. Override with config:
+        //   ai_api_key  - the provider API key (Groq: console.groq.com). Falls back to OPENAI_API_KEY.
+        //   ai_endpoint - OpenAI-compatible base URL (default Groq; e.g. https://api.openai.com/v1 for OpenAI).
+        //   ai_model    - model id (default a Groq Llama model).
+        private const string DefaultEndpoint = "https://api.groq.com/openai/v1";
+        private const string DefaultModel = "llama-3.3-70b-versatile";
+
         /// <summary>
-        /// Registers an OpenAI-backed <see cref="IChatClient"/> and the hardened
-        /// <see cref="IGptChatService"/>. Reads "OPENAI_API_KEY" and an optional
-        /// "openai_model" (defaults to a current, cost-effective model).
+        /// Registers an OpenAI-compatible <see cref="IChatClient"/> (Groq by default) and the
+        /// hardened <see cref="IGptChatService"/> circuit-breaker.
         /// </summary>
         public static IServiceCollection AddGptChatService(this IServiceCollection services, IConfiguration configuration)
         {
-            var apiKey = configuration["OPENAI_API_KEY"] ?? string.Empty;
-            var model = configuration["openai_model"];
-            if (string.IsNullOrWhiteSpace(model))
+            var apiKey = configuration["ai_api_key"]
+                         ?? configuration["GROQ_API_KEY"]
+                         ?? configuration["OPENAI_API_KEY"]
+                         ?? string.Empty;
+
+            var endpoint = configuration["ai_endpoint"];
+            if (string.IsNullOrWhiteSpace(endpoint))
             {
-                model = "gpt-4o-mini";
+                endpoint = DefaultEndpoint;
             }
 
-            IChatClient chatClient = new OpenAIClient(new System.ClientModel.ApiKeyCredential(apiKey))
+            var model = configuration["ai_model"] ?? configuration["openai_model"];
+            if (string.IsNullOrWhiteSpace(model))
+            {
+                model = DefaultModel;
+            }
+
+            var options = new OpenAIClientOptions { Endpoint = new Uri(endpoint) };
+
+            IChatClient chatClient = new OpenAIClient(new System.ClientModel.ApiKeyCredential(apiKey), options)
                 .GetChatClient(model)
                 .AsIChatClient();
 


### PR DESCRIPTION
`%gpt` / `@kinobotz` failed with OpenAI `insufficient_quota` (the OpenAI **API** needs paid credits — the ChatGPT subscription never covered it). This switches the default provider to **Groq's free tier**, which is OpenAI-compatible, so it's a config-only swap thanks to the `Microsoft.Extensions.AI` refactor.

## Provider is now config-driven
| Config var | Purpose | Default |
|---|---|---|
| `ai_api_key` | provider API key (falls back to `OPENAI_API_KEY`) | — |
| `ai_endpoint` | OpenAI-compatible base URL | `https://api.groq.com/openai/v1` |
| `ai_model` | model id | `llama-3.3-70b-versatile` |

To go back to OpenAI later: set `ai_endpoint=https://api.openai.com/v1`, `ai_api_key=<openai key>`, `ai_model=gpt-4o-mini`. No code change.

## To activate (after merge)
1. Get a free key at **console.groq.com**.
2. `heroku config:set ai_api_key=<groq key> -a kinobotz`

The existing quota/auth circuit-breaker still covers Groq's free-tier 429s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)