### PR TITLE
CI: gated live integration checks (Twitch connection + overlay e2e) on every PR

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,52 @@
+name: Integration Tests (gated, live)
+
+# Live smoke tests against real services (Twitch + the deployed app). They run on every
+# PR per the project's choice. The Twitch job is GATED on the KINOBOTZ_BOT_TOKEN secret:
+# without it the tests return early (pass as a no-op), so forks / unconfigured repos stay
+# green. workflow_dispatch allows manual re-runs.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  twitch-connection:
+    name: Twitch connection (live; gated on KINOBOTZ_BOT_TOKEN)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Twitch integration tests (skip when secret absent)
+        run: >
+          dotnet test backend/twitchBot.sln -c Release
+          --filter "FullyQualifiedName~TwitchConnectionIntegrationTests"
+        env:
+          KINOBOTZ_BOT_TOKEN: ${{ secrets.KINOBOTZ_BOT_TOKEN }}
+          KINOBOTZ_BOT_USERNAME: ${{ secrets.KINOBOTZ_BOT_USERNAME }}
+
+  overlay-e2e:
+    name: Overlay SignalR e2e (live; against deployed app)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - run: npx playwright install --with-deps chromium
+
+      - name: Overlay e2e (against deployed app; OVERLAY_APP/OVERLAY_API override the prod defaults)
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -436,3 +436,8 @@ $RECYCLE.BIN/
 # Local test artifacts
 .playwright-mcp/
 k1no-tv-vite-live.png
+
+# Playwright e2e
+frontend/test-results/
+frontend/playwright-report/
+frontend/playwright/.cache/

--- a/frontend/e2e/overlay.spec.js
+++ b/frontend/e2e/overlay.spec.js
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// End-to-end overlay / SignalR test against the DEPLOYED app (the nginx CSP and the
+// SignalR WebSocket path only exist in the deployed container, not in Vite dev/preview —
+// which is why a non-browser test can't catch the CSP regression that degraded TTS).
+//
+// It loads the real overlay and asserts:
+//  1. no CSP violation (the WebSocket uses wss://, the audio uses blob: — both must be allowed),
+//  2. the overlay receives audio pushed to the hub endpoint exactly like the worker does after TTS.
+//
+// Configure (defaults are prod):
+//   OVERLAY_APP  - overlay origin           (default https://k1no.tv)
+//   OVERLAY_API  - webapi origin (the hub)  (default https://kinobotz.herokuapp.com)
+const APP = process.env.OVERLAY_APP || 'https://k1no.tv';
+const API = process.env.OVERLAY_API || 'https://kinobotz.herokuapp.com';
+
+test('overlay: no CSP violation (wss + blob) and receives pushed audio', async ({ page, request }) => {
+  const testId = `e2e-${Date.now()}`;
+  const received = [];
+
+  // Capture CSP violations the reliable way (the securitypolicyviolation event), not console.
+  await page.addInitScript(() => {
+    window.__cspViolations = [];
+    document.addEventListener('securitypolicyviolation', (e) => {
+      window.__cspViolations.push(`${e.effectiveDirective || e.violatedDirective} blocked ${e.blockedURI}`);
+    });
+  });
+
+  page.on('console', (msg) => {
+    if (msg.text().startsWith('received')) received.push(msg.text()); // OverlayApp logs 'received<msg>'
+  });
+
+  await page.goto(`${APP}/overlay/${testId}`, { waitUntil: 'load' });
+  await page.waitForTimeout(4000); // let SignalR negotiate + attempt the wss WebSocket
+
+  // simulate the worker delivering TTS audio for this overlay id (triggers the blob: audio path too)
+  const audio = Buffer.from([0xff, 0xfb, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00]); // minimal mp3 frame header
+  const resp = await request.post(`${API}/overlay/audio/${testId}`, {
+    data: audio,
+    headers: { 'content-type': 'application/octet-stream' },
+  });
+  expect(resp.status(), 'POST /overlay/audio/{id} should return 200').toBe(200);
+
+  // the overlay must receive the SignalR broadcast (client method == testId)
+  await expect.poll(() => received.length, { message: 'overlay never received the SignalR audio message' }).toBeGreaterThan(0);
+
+  await page.waitForTimeout(1500); // let the blob: audio src be set/loaded (media-src CSP applies here)
+  const violations = await page.evaluate(() => window.__cspViolations || []);
+  expect(violations, `overlay hit CSP violation(s):\n${violations.join('\n')}`).toEqual([]);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.61.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "@vue/test-utils": "^2.4.6",
@@ -1068,6 +1069,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3950,6 +3967,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview --port 8080",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.61.0",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "@vue/test-utils": "^2.4.6",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+// E2E tests run against the DEPLOYED app — the nginx CSP (and SignalR/WebSocket path)
+// only exist there, not in the Vite dev/preview build.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: 'list',
+  use: {
+    headless: true,
+    ignoreHTTPSErrors: true,
+  },
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,5 +20,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    // unit tests live under src/; e2e/ is Playwright (npm run test:e2e), not Vitest
+    include: ['src/**/*.{test,spec}.{js,ts,jsx,tsx}'],
   },
 });


### PR DESCRIPTION
Runs the integration tests we built as **PR checks**, gated.

## `integration-tests.yml` (on every PR + manual dispatch)
- **twitch-connection** — runs `TwitchConnectionIntegrationTests` **live**, gated on the `KINOBOTZ_BOT_TOKEN` secret. Without the secret the tests return early (pass), so forks/unconfigured repos stay green. *(Heads-up: when the secret is set, each PR run connects the bot from CI and posts a test message in #kinobotz — that's the per-PR trade-off you chose.)*
- **overlay-e2e** — runs the Playwright overlay/SignalR test against the deployed app (no secret needed; posts to a throwaway overlay id).

## Required setup (repo secrets)
For the Twitch job to actually run live, add:
- `KINOBOTZ_BOT_TOKEN` — the bot chat token
- `KINOBOTZ_BOT_USERNAME` — `kinobotz`

(I can set these via `gh secret set` for you.)

## Notes
- These are **live smoke tests** — they validate the running system, not a PR's unbuilt frontend changes.
- The bot chat token has no auto-refresh, so `KINOBOTZ_BOT_TOKEN` will need updating when it rotates (or fix bot-token auto-refresh separately).
- To make them blocking, mark the two checks as required in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)